### PR TITLE
Only import pynotify if notifications are enabled in settings

### DIFF
--- a/roficlip.py
+++ b/roficlip.py
@@ -32,7 +32,6 @@ import struct
 import gobject
 import gtk
 import yaml
-import pynotify
 from subprocess import PIPE, Popen
 from xdg import BaseDirectory
 from docopt import docopt
@@ -67,6 +66,7 @@ class ClipboardManager():
 
         # Init notifications
         if self.cfg['notify']:
+            import pynotify
             pynotify.init(name)
 
     def daemon(self):


### PR DESCRIPTION
No reason to require pynotify if the user has notifications disabled. Saves having to install some unneeded libraries.